### PR TITLE
Add profiling library for simple function profiling

### DIFF
--- a/fimsrg/utility/CMakeLists.txt
+++ b/fimsrg/utility/CMakeLists.txt
@@ -1,1 +1,2 @@
 add_subdirectory(checks)
+add_subdirectory(profiling)

--- a/fimsrg/utility/profiling/CMakeLists.txt
+++ b/fimsrg/utility/profiling/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(internal)

--- a/fimsrg/utility/profiling/CMakeLists.txt
+++ b/fimsrg/utility/profiling/CMakeLists.txt
@@ -1,1 +1,18 @@
 add_subdirectory(internal)
+
+add_library(
+    fermimsrg_profiling
+    profile_report.h profile_report.cc
+    function_profile.h
+)
+add_library(fermimsrg::profiling ALIAS fermimsrg_profiling)
+target_include_directories(
+    fermimsrg_profiling
+    PUBLIC
+    ${FIMSRG_ROOT_DIR}
+)
+target_link_libraries(
+    fermimsrg_profiling
+    PUBLIC
+    fermimsrg_profiling_internal
+)

--- a/fimsrg/utility/profiling/function_profile.h
+++ b/fimsrg/utility/profiling/function_profile.h
@@ -14,13 +14,16 @@
 
 #include "fimsrg/utility/profiling/internal/single_event_profiler.h"
 
-#define ProfileFunction()                                                \
-  const auto prof = fimsrg::internal::MakeSingleEventProfiler(__func__); \
+#define ProfileFunction()                                             \
+  const auto prof =                                                   \
+      fimsrg::internal::SingleEventProfiler::MakeSingleEventProfiler( \
+          __func__);                                                  \
   (void)prof;
 
-#define ProfileFunctionWithSize(x)                                    \
-  const auto prof =                                                   \
-      fimsrg::internal::MakeSingleEventProfilerWithSize(__func__, x); \
+#define ProfileFunctionWithSize(x)                                            \
+  const auto prof =                                                           \
+      fimsrg::internal::SingleEventProfiler::MakeSingleEventProfilerWithSize( \
+          __func__, x);                                                       \
   (void)prof;
 
 #endif  // FIMSRG_UTILITY_PROFILING_FUNCTION_PROFILE_H_

--- a/fimsrg/utility/profiling/function_profile.h
+++ b/fimsrg/utility/profiling/function_profile.h
@@ -1,0 +1,26 @@
+// Copyright 2022 Matthias Heinz
+//
+// This file provides ProfileFunction() and ProfileFunctionWithSize(x),
+// two macros designed to make profiling a function easy.
+// Placing one of these calls at the beginning of a function body
+// will generate a profiling event for each function call
+// with the event name being the function name.
+//
+// ProfileFunctionWithSize(x) gives the option to provide a size x
+// as a parameter. This helps to distinguish different function calls
+// of different sizes that have a runtime that should depend on the size.
+#ifndef FIMSRG_UTILITY_PROFILING_FUNCTION_PROFILE_H_
+#define FIMSRG_UTILITY_PROFILING_FUNCTION_PROFILE_H_
+
+#include "fimsrg/utility/profiling/internal/single_event_profiler.h"
+
+#define ProfileFunction()                                                \
+  const auto prof = fimsrg::internal::MakeSingleEventProfiler(__func__); \
+  (void)prof;
+
+#define ProfileFunctionWithSize(x)                                    \
+  const auto prof =                                                   \
+      fimsrg::internal::MakeSingleEventProfilerWithSize(__func__, x); \
+  (void)prof;
+
+#endif  // FIMSRG_UTILITY_PROFILING_FUNCTION_PROFILE_H_

--- a/fimsrg/utility/profiling/internal/CMakeLists.txt
+++ b/fimsrg/utility/profiling/internal/CMakeLists.txt
@@ -2,6 +2,7 @@ add_library(
     fermimsrg_profiling_internal
     profiling_event_data.h
     profiling_data.h profiling_data.cc
+    profiling_database.h profiling_database.cc
 )
 target_include_directories(
     fermimsrg_profiling_internal
@@ -10,6 +11,8 @@ target_include_directories(
 )
 target_link_libraries(
     fermimsrg_profiling_internal
+    PUBLIC
+    absl::flat_hash_map
     PRIVATE
     fermimsrg::checks
 )

--- a/fimsrg/utility/profiling/internal/CMakeLists.txt
+++ b/fimsrg/utility/profiling/internal/CMakeLists.txt
@@ -15,4 +15,5 @@ target_link_libraries(
     absl::flat_hash_map
     PRIVATE
     fermimsrg::checks
+    fmt::fmt
 )

--- a/fimsrg/utility/profiling/internal/CMakeLists.txt
+++ b/fimsrg/utility/profiling/internal/CMakeLists.txt
@@ -3,6 +3,7 @@ add_library(
     profiling_event_data.h
     profiling_data.h profiling_data.cc
     profiling_database.h profiling_database.cc
+    single_event_profiler.h single_event_profiler.cc
 )
 target_include_directories(
     fermimsrg_profiling_internal
@@ -16,4 +17,6 @@ target_link_libraries(
     PRIVATE
     fermimsrg::checks
     fmt::fmt
+    absl::time
+    absl::strings
 )

--- a/fimsrg/utility/profiling/internal/CMakeLists.txt
+++ b/fimsrg/utility/profiling/internal/CMakeLists.txt
@@ -1,0 +1,15 @@
+add_library(
+    fermimsrg_profiling_internal
+    profiling_event_data.h
+    profiling_data.h profiling_data.cc
+)
+target_include_directories(
+    fermimsrg_profiling_internal
+    PUBLIC
+    ${FIMSRG_ROOT_DIR}
+)
+target_link_libraries(
+    fermimsrg_profiling_internal
+    PRIVATE
+    fermimsrg::checks
+)

--- a/fimsrg/utility/profiling/internal/profiling_data.cc
+++ b/fimsrg/utility/profiling/internal/profiling_data.cc
@@ -1,0 +1,28 @@
+// Copyright 2022 Matthias Heinz
+#include "fimsrg/utility/profiling/internal/profiling_data.h"
+
+// PUBLIC
+#include "fimsrg/utility/profiling/internal/profiling_event_data.h"
+
+// PRIVATE
+#include "fimsrg/utility/checks/assert.h"
+
+namespace fimsrg {
+namespace internal {
+
+void ProfilingData::AddProfilingEvent(const ProfilingEventData& event_data) {
+  if (this->event_name != "") {
+    Expects(this->event_name == event_data.event_name);
+  } else {
+    this->event_name = event_data.event_name;
+  }
+  this->event_count += 1;
+  this->wall_time += event_data.wall_time;
+}
+
+bool operator<(const ProfilingData& a, const ProfilingData& b) {
+  return a.wall_time < b.wall_time;
+}
+
+}  // namespace internal
+}  // namespace fimsrg

--- a/fimsrg/utility/profiling/internal/profiling_data.h
+++ b/fimsrg/utility/profiling/internal/profiling_data.h
@@ -1,0 +1,44 @@
+// Copyright 2022 Matthias Heinz
+#ifndef FIMSRG_UTILITY_PROFILING_INTERNAL_PROFILING_DATA_H_
+#define FIMSRG_UTILITY_PROFILING_INTERNAL_PROFILING_DATA_H_
+
+#include <cstdlib>
+#include <string>
+#include <utility>
+
+#include "fimsrg/utility/profiling/internal/profiling_event_data.h"
+
+namespace fimsrg {
+namespace internal {
+
+// Collected profiling data across multiple events.
+struct ProfilingData {
+  std::string event_name = "";
+  std::size_t event_count = 0;
+  double wall_time = 0.0;
+
+  // Add single profiling event to the current collection.
+  //
+  // Requires both to have the same event_name.
+  // A notable exception is if the event_name in ProfilingData is "".
+  // Then, it will take on the event_name of the profiling event.
+  void AddProfilingEvent(const ProfilingEventData& event_data);
+};
+
+// Swap profiling data.
+inline void swap(ProfilingData& a, ProfilingData& b) noexcept {
+  using std::swap;
+  swap(a.event_name, b.event_name);
+  swap(a.event_count, b.event_count);
+  swap(a.wall_time, b.wall_time);
+}
+
+// Determine whether profiiling data a is less expensive than b.
+//
+// Gives a total ordering to profiling data for reports.
+bool operator<(const ProfilingData& a, const ProfilingData& b);
+
+}  // namespace internal
+}  // namespace fimsrg
+
+#endif  // FIMSRG_UTILITY_PROFILING_INTERNAL_PROFILING_DATA_H_

--- a/fimsrg/utility/profiling/internal/profiling_database.cc
+++ b/fimsrg/utility/profiling/internal/profiling_database.cc
@@ -34,11 +34,6 @@ inline std::vector<ProfilingData> SortProfilingData(
   return events;
 }
 
-inline std::string GetProfileReportHeader() {
-  return fmt::format("{:50} {:11} {:11} {:11}\n", "EVENT NAME", "NUM EVENTS",
-                     "WALLTIME(s)", "PER CALL(s)");
-}
-
 inline std::string GetProfileReportString(const ProfilingData& data) {
   double per_call = 0.0;
   if (data.event_count > 0) {
@@ -88,7 +83,8 @@ std::vector<std::string> ProfilingDatabase::GenerateProfileReportEntries()
 }
 
 std::string ProfilingDatabase::GetProfileReportHeader() const {
-  return GetProfileReportHeader();
+  return fmt::format("{:50} {:11} {:11} {:11}\n", "EVENT NAME", "NUM EVENTS",
+                     "WALLTIME(s)", "PER CALL(s)");
 }
 
 ProfilingDatabase::ProfilingDatabase() {}

--- a/fimsrg/utility/profiling/internal/profiling_database.cc
+++ b/fimsrg/utility/profiling/internal/profiling_database.cc
@@ -59,7 +59,7 @@ void ProfilingDatabase::AddProfilingEvent(
 }
 
 void ProfilingDatabase::WriteProfileReport(std::string path_to_file) const {
-  const auto sorted_data = SortProfilingData(event_data_);
+  const auto entries = GenerateProfileReportEntries();
 
   std::ofstream file(path_to_file);
   fimsrg::CheckForError(
@@ -69,9 +69,26 @@ void ProfilingDatabase::WriteProfileReport(std::string path_to_file) const {
               .c_str()));
 
   file << GetProfileReportHeader() << "\n";
-  for (auto it = sorted_data.rbegin(); it != sorted_data.rend(); ++it) {
-    file << GetProfileReportString(*it) << "\n";
+  for (const auto& entry : entries) {
+    file << entry << "\n";
   }
+}
+
+std::vector<std::string> ProfilingDatabase::GenerateProfileReportEntries()
+    const {
+  const auto sorted_data = SortProfilingData(event_data_);
+  std::vector<std::string> entries;
+  entries.reserve(sorted_data.size());
+
+  for (auto it = sorted_data.rbegin(); it != sorted_data.rend(); ++it) {
+    entries.push_back(GetProfileReportString(*it));
+  }
+
+  return entries;
+}
+
+std::string ProfilingDatabase::GetProfileReportHeader() const {
+  return GetProfileReportHeader();
 }
 
 ProfilingDatabase::ProfilingDatabase() {}

--- a/fimsrg/utility/profiling/internal/profiling_database.cc
+++ b/fimsrg/utility/profiling/internal/profiling_database.cc
@@ -25,7 +25,7 @@ inline std::vector<ProfilingData> SortProfilingData(
   std::vector<ProfilingData> events;
   events.reserve(event_data.size());
 
-  for (const auto i : event_data) {
+  for (const auto& i : event_data) {
     events.push_back(i.second);
   }
 

--- a/fimsrg/utility/profiling/internal/profiling_database.cc
+++ b/fimsrg/utility/profiling/internal/profiling_database.cc
@@ -1,14 +1,52 @@
 // Copyright 2022 Matthias Heinz
 #include "fimsrg/utility/profiling/internal/profiling_database.h"
 
+#include <algorithm>
+#include <fstream>
 #include <string>
+#include <vector>
 
 #include "absl/container/flat_hash_map.h"
 
+// PRIVATE
+#include "fmt/core.h"
+
+#include "fimsrg/utility/profiling/internal/profiling_data.h"
 #include "fimsrg/utility/profiling/internal/profiling_event_data.h"
+
+// PRIVATE
+#include "fimsrg/utility/checks/error.h"
 
 namespace fimsrg {
 namespace internal {
+
+inline std::vector<ProfilingData> SortProfilingData(
+    const absl::flat_hash_map<std::string, ProfilingData>& event_data) {
+  std::vector<ProfilingData> events;
+  events.reserve(event_data.size());
+
+  for (const auto i : event_data) {
+    events.push_back(i.second);
+  }
+
+  std::sort(events.begin(), events.end());
+
+  return events;
+}
+
+inline std::string GetProfileReportHeader() {
+  return fmt::format("{:50} {:11} {:11} {:11}\n", "EVENT NAME", "NUM EVENTS",
+                     "WALLTIME(s)", "PER CALL(s)");
+}
+
+inline std::string GetProfileReportString(const ProfilingData& data) {
+  double per_call = 0.0;
+  if (data.event_count > 0) {
+    per_call = data.wall_time / data.event_count;
+  }
+  return fmt::format("{:50} {:11} {:11.6} {:11.6}\n", data.event_name,
+                     data.event_count, data.wall_time, per_call);
+}
 
 ProfilingDatabase& ProfilingDatabase::GetInstance() {
   static ProfilingDatabase instance;
@@ -21,8 +59,19 @@ void ProfilingDatabase::AddProfilingEvent(
 }
 
 void ProfilingDatabase::WriteProfileReport(std::string path_to_file) const {
-  (void)path_to_file;
-  // TODO(mheinz): implement
+  const auto sorted_data = SortProfilingData(event_data_);
+
+  std::ofstream file(path_to_file);
+  fimsrg::CheckForError(
+      !file.is_open(),
+      ErrorMessage(
+          fmt::format("Failed to open profile report file at {}", path_to_file)
+              .c_str()));
+
+  file << GetProfileReportHeader() << "\n";
+  for (auto it = sorted_data.rbegin(); it != sorted_data.rend(); ++it) {
+    file << GetProfileReportString(*it) << "\n";
+  }
 }
 
 ProfilingDatabase::ProfilingDatabase() {}

--- a/fimsrg/utility/profiling/internal/profiling_database.cc
+++ b/fimsrg/utility/profiling/internal/profiling_database.cc
@@ -1,0 +1,33 @@
+// Copyright 2022 Matthias Heinz
+#include "fimsrg/utility/profiling/internal/profiling_database.h"
+
+#include <string>
+
+#include "absl/container/flat_hash_map.h"
+
+#include "fimsrg/utility/profiling/internal/profiling_event_data.h"
+
+namespace fimsrg {
+namespace internal {
+
+ProfilingDatabase& ProfilingDatabase::GetInstance() {
+  static ProfilingDatabase instance;
+  return instance;
+}
+
+void ProfilingDatabase::AddProfilingEvent(
+    const ProfilingEventData& event_data) {
+  event_data_[event_data.event_name].AddProfilingEvent(event_data);
+}
+
+void ProfilingDatabase::WriteProfileReport(std::string path_to_file) const {
+  (void)path_to_file;
+  // TODO(mheinz): implement
+}
+
+ProfilingDatabase::ProfilingDatabase() {}
+
+ProfilingDatabase::~ProfilingDatabase() {}
+
+}  // namespace internal
+}  // namespace fimsrg

--- a/fimsrg/utility/profiling/internal/profiling_database.h
+++ b/fimsrg/utility/profiling/internal/profiling_database.h
@@ -1,0 +1,45 @@
+// Copyright 2022 Matthias Heinz
+#ifndef FIMSRG_UTILITY_PROFILING_INTERNAL_PROFILING_DATABASE_H_
+#define FIMSRG_UTILITY_PROFILING_INTERNAL_PROFILING_DATABASE_H_
+
+#include <string>
+
+#include "absl/container/flat_hash_map.h"
+
+#include "fimsrg/utility/profiling/internal/profiling_data.h"
+#include "fimsrg/utility/profiling/internal/profiling_event_data.h"
+
+namespace fimsrg {
+namespace internal {
+
+// Singleton class to contain full set of profiling data.
+class ProfilingDatabase {
+ public:
+  // Get database singleton instance.
+  static ProfilingDatabase& GetInstance();
+
+  // Database is a singleton.
+  ProfilingDatabase(const ProfilingDatabase&) = delete;
+
+  // Database is a singleton.
+  ProfilingDatabase& operator=(const ProfilingDatabase&) = delete;
+
+  // Add data for an event into the database.
+  void AddProfilingEvent(const ProfilingEventData& event_data);
+
+  // Write profile report to a specified file.
+  void WriteProfileReport(std::string path_to_file) const;
+
+ private:
+  absl::flat_hash_map<std::string, ProfilingData> event_data_;
+
+  // Private constructor.
+  ProfilingDatabase();
+
+  // Private destructor.
+  ~ProfilingDatabase();
+};
+}  // namespace internal
+}  // namespace fimsrg
+
+#endif  // FIMSRG_UTILITY_PROFILING_INTERNAL_PROFILING_DATABASE_H_

--- a/fimsrg/utility/profiling/internal/profiling_database.h
+++ b/fimsrg/utility/profiling/internal/profiling_database.h
@@ -3,6 +3,7 @@
 #define FIMSRG_UTILITY_PROFILING_INTERNAL_PROFILING_DATABASE_H_
 
 #include <string>
+#include <vector>
 
 #include "absl/container/flat_hash_map.h"
 
@@ -29,6 +30,12 @@ class ProfilingDatabase {
 
   // Write profile report to a specified file.
   void WriteProfileReport(std::string path_to_file) const;
+
+  // Get a vector of profile report strings (sorted by decreasing cost).
+  std::vector<std::string> GenerateProfileReportEntries() const;
+
+  // Get a header for the profiling report.
+  std::string GetProfileReportHeader() const;
 
  private:
   absl::flat_hash_map<std::string, ProfilingData> event_data_;

--- a/fimsrg/utility/profiling/internal/profiling_event_data.h
+++ b/fimsrg/utility/profiling/internal/profiling_event_data.h
@@ -1,0 +1,27 @@
+// Copyright 2022 Matthias Heinz
+#ifndef FIMSRG_UTILITY_PROFILING_INTERNAL_PROFILING_EVENT_DATA_H_
+#define FIMSRG_UTILITY_PROFILING_INTERNAL_PROFILING_EVENT_DATA_H_
+
+#include <string>
+#include <utility>
+
+namespace fimsrg {
+namespace internal {
+
+// Data for a single profiling event.
+struct ProfilingEventData {
+  std::string event_name = "";
+  double wall_time = 0.0;
+};
+
+// Swap two profiling event data.
+inline void swap(ProfilingEventData& a, ProfilingEventData& b) noexcept {
+  using std::swap;
+  swap(a.event_name, b.event_name);
+  swap(a.wall_time, b.wall_time);
+}
+
+}  // namespace internal
+}  // namespace fimsrg
+
+#endif  // FIMSRG_UTILITY_PROFILING_INTERNAL_PROFILING_EVENT_DATA_H_

--- a/fimsrg/utility/profiling/internal/single_event_profiler.cc
+++ b/fimsrg/utility/profiling/internal/single_event_profiler.cc
@@ -1,0 +1,41 @@
+// Copyright 2022 Matthias Heinz
+#include "fimsrg/utility/profiling/internal/single_event_profiler.h"
+
+#include <cstdlib>
+#include <memory>
+#include <string>
+
+// PRIVATE
+#include "absl/strings/str_cat.h"
+#include "absl/time/clock.h"
+
+// PRIVATE
+#include "fimsrg/utility/profiling/internal/profiling_database.h"
+
+namespace fimsrg {
+namespace internal {
+
+std::unique_ptr<SingleEventProfiler>
+SingleEventProfiler::MakeSingleEventProfiler(std::string event_name) {
+  return std::make_unique<SingleEventProfiler>(event_name);
+}
+
+std::unique_ptr<SingleEventProfiler>
+SingleEventProfiler::MakeSingleEventProfilerWithSize(std::string event_name,
+                                                     std::size_t size) {
+  return std::make_unique<SingleEventProfiler>(
+      absl::StrCat(event_name, ", size = ", std::to_string(size)));
+}
+
+SingleEventProfiler::SingleEventProfiler(std::string event_name)
+    : event_name_(event_name), start_time_ns_(absl::GetCurrentTimeNanos()) {}
+
+SingleEventProfiler::~SingleEventProfiler() {
+  const auto end_time_ns = absl::GetCurrentTimeNanos();
+  auto& prof_db = ProfilingDatabase::GetInstance();
+  double elapsed_time_s = (end_time_ns - start_time_ns_) / 1e9;
+  prof_db.AddProfilingEvent({event_name_, elapsed_time_s});
+}
+
+}  // namespace internal
+}  // namespace fimsrg

--- a/fimsrg/utility/profiling/internal/single_event_profiler.h
+++ b/fimsrg/utility/profiling/internal/single_event_profiler.h
@@ -1,0 +1,52 @@
+// Copyright 2022 Matthias Heinz
+#ifndef FIMSRG_UTILITY_PROFILING_INTERNAL_SINGLE_EVENT_PROFILER_H_
+#define FIMSRG_UTILITY_PROFILING_INTERNAL_SINGLE_EVENT_PROFILER_H_
+
+#include <cstdint>
+#include <cstdlib>
+#include <memory>
+#include <string>
+
+namespace fimsrg {
+namespace internal {
+
+class SingleEventProfiler {
+ public:
+  // Create a unique single event profiler for a given event.
+  static std::unique_ptr<SingleEventProfiler> MakeSingleEventProfiler(
+      std::string event_name);
+
+  // Create a unique single event profiler for an event with a specified size.
+  static std::unique_ptr<SingleEventProfiler> MakeSingleEventProfilerWithSize(
+      std::string event_name, std::size_t size);
+
+  // Constructor.
+  //
+  // You should probably not call this directly.
+  // Prefer the factor function MakeSingleEventProfiler(event_name).
+  explicit SingleEventProfiler(std::string event_name);
+
+  // Destructor.
+  ~SingleEventProfiler();
+
+  // Cannot be copied.
+  SingleEventProfiler(const SingleEventProfiler&) = delete;
+
+  // Cannot be copied.
+  void operator=(const SingleEventProfiler&) = delete;
+
+  // Cannot be moved.
+  SingleEventProfiler(SingleEventProfiler&&) = delete;
+
+  // Cannot be moved.
+  void operator=(SingleEventProfiler&&) = delete;
+
+ private:
+  std::string event_name_;
+  std::int64_t start_time_ns_;
+};
+
+}  // namespace internal
+}  // namespace fimsrg
+
+#endif  // FIMSRG_UTILITY_PROFILING_INTERNAL_SINGLE_EVENT_PROFILER_H_

--- a/fimsrg/utility/profiling/profile_report.cc
+++ b/fimsrg/utility/profiling/profile_report.cc
@@ -1,0 +1,16 @@
+// Copyright 2022 Matthias Heinz
+#include "fimsrg/utility/profiling/profile_report.h"
+
+#include <string>
+
+// PRIVATE
+#include "fimsrg/utility/profiling/internal/profiling_database.h"
+
+namespace fimsrg {
+
+void WriteProfileReportToFile(std::string path_to_file) {
+  const auto& prof_db = fimsrg::internal::ProfilingDatabase::GetInstance();
+  prof_db.WriteProfileReport(path_to_file);
+}
+
+}  // namespace fimsrg

--- a/fimsrg/utility/profiling/profile_report.cc
+++ b/fimsrg/utility/profiling/profile_report.cc
@@ -13,4 +13,14 @@ void WriteProfileReportToFile(std::string path_to_file) {
   prof_db.WriteProfileReport(path_to_file);
 }
 
+std::vector<std::string> GetProfileReportEntries() {
+  const auto& prof_db = fimsrg::internal::ProfilingDatabase::GetInstance();
+  return prof_db.GenerateProfileReportEntries();
+}
+
+std::string GetProfileReportHeader() {
+  const auto& prof_db = fimsrg::internal::ProfilingDatabase::GetInstance();
+  return prof_db.GetProfileReportHeader();
+}
+
 }  // namespace fimsrg

--- a/fimsrg/utility/profiling/profile_report.h
+++ b/fimsrg/utility/profiling/profile_report.h
@@ -1,0 +1,14 @@
+// Copyright 2022 Matthias Heinz
+#ifndef FIMSRG_UTILITY_PROFILING_PROFILE_REPORT_H_
+#define FIMSRG_UTILITY_PROFILING_PROFILE_REPORT_H_
+
+#include <string>
+
+namespace fimsrg {
+
+// Write a profile report to the file provided.
+void WriteProfileReportToFile(std::string path_to_file);
+
+}  // namespace fimsrg
+
+#endif  // FIMSRG_UTILITY_PROFILING_PROFILE_REPORT_H_

--- a/fimsrg/utility/profiling/profile_report.h
+++ b/fimsrg/utility/profiling/profile_report.h
@@ -3,11 +3,18 @@
 #define FIMSRG_UTILITY_PROFILING_PROFILE_REPORT_H_
 
 #include <string>
+#include <vector>
 
 namespace fimsrg {
 
 // Write a profile report to the file provided.
 void WriteProfileReportToFile(std::string path_to_file);
+
+// Get a vector of sorted (most to least expensive) entries.
+std::vector<std::string> GetProfileReportEntries();
+
+// Get the header of a profile report.
+std::string GetProfileReportHeader();
 
 }  // namespace fimsrg
 

--- a/tests/fimsrg/utility/CMakeLists.txt
+++ b/tests/fimsrg/utility/CMakeLists.txt
@@ -1,1 +1,2 @@
 add_subdirectory(checks)
+add_subdirectory(profiling)

--- a/tests/fimsrg/utility/profiling/CMakeLists.txt
+++ b/tests/fimsrg/utility/profiling/CMakeLists.txt
@@ -1,0 +1,12 @@
+add_executable(
+    function_profile_test
+    function_profile_test.cc
+)
+target_link_libraries(
+    function_profile_test
+    fermimsrg::profiling
+    Catch2::Catch2WithMain
+)
+catch_discover_tests(
+    function_profile_test
+)

--- a/tests/fimsrg/utility/profiling/function_profile_test.cc
+++ b/tests/fimsrg/utility/profiling/function_profile_test.cc
@@ -1,0 +1,27 @@
+// Copyright 2022 Matthias Heinz
+#include "fimsrg/utility/profiling/function_profile.h"
+
+#include "catch2/catch.hpp"
+
+#include "fimsrg/utility/profiling/profile_report.h"
+
+static int One() {
+  ProfileFunction();
+  return 1;
+}
+
+static int TimesTen(int val) {
+  ProfileFunctionWithSize(val);
+  return val * 10;
+}
+
+TEST_CASE("Test profiling two functions gives two profile entries.") {
+  int val = 0;
+
+  val += One();
+  val += TimesTen(100);
+
+  REQUIRE(val == 1001);
+  const auto entries = fimsrg::GetProfileReportEntries();
+  REQUIRE(entries.size() == 2);
+}


### PR DESCRIPTION
The goal is to provide an extremely simple interface for the basic profiling of entire functions.
This is implemented in `function_profile.h`, via the `ProfileFunction()` and `ProfileFunctionWithSize(size)` macros.
These macros populate the function body with a profiler object that will log a profiling event at the end of the function (when it is destroyed).
Profiling information is not written to file by default, but can be written to a report file using the `profile_report.h` API.